### PR TITLE
4分の1地域メッシュの計算式の修正

### DIFF
--- a/lib/meshcode2LatLng.js
+++ b/lib/meshcode2LatLng.js
@@ -81,8 +81,8 @@ http://opensource.org/licenses/mit-license.php
     lng = (code.u+100)*3600 + code.v*7.5*60 + code.w*45;
     south = lat + ((code.m > 2 ? (code.n > 2 ? ((code.n + code.m) > 5 ? 3 : 2) : 2) : (code.n > 2 ? 1 : 0))) * 7.5;
     north = lat + ((code.m > 2 ? (code.n > 2 ? ((code.n + code.m) > 5 ? 3 : 2) : 2) : (code.n > 2 ? 1 : 0)) + 1) * 7.5;
-    west = lng + ((code.m%2 == 0 ? (code.n%2 == 0 ? ((code.n%2 + code.m%2) > 1 ? 3 : 2) : 2) : (code.n%2 == 0 ? 1 : 0))) * 11.25;
-    east = lng + ((code.m%2 == 0 ? (code.n%2 == 0 ? ((code.n%2 + code.m%2) > 1 ? 3 : 2) : 2) : (code.n%2 == 0 ? 1 : 0)) + 1) * 11.25;
+    west = lng + ((code.m%2 == 0 ? (code.n%2 == 0 ? 3 : 2) : (code.n%2 == 0 ? 1 : 0))) * 11.25;
+    east = lng + ((code.m%2 == 0 ? (code.n%2 == 0 ? 3 : 2) : (code.n%2 == 0 ? 1 : 0)) + 1) * 11.25;
     return {"south":south/3600, "west":west/3600, "north":north/3600, "east":east/3600};
   }
 


### PR DESCRIPTION
4分の1地域メッシュの計算式に誤りがありました。
末尾が`22`または`42`のメッシュについて、足し合わせる経度が足りず、1つ左のメッシュへオフセットしてしまっています。

可視化したものです。
修正前 (色が濃くなっている部分は2つのメッシュが重なっています。)
<img width="1439" alt="スクリーンショット 2019-05-13 18 09 29" src="https://user-images.githubusercontent.com/32349530/57610042-08dbf100-75ab-11e9-979b-41dfeebc0e65.png">

修正後
<img width="1440" alt="スクリーンショット 2019-05-13 18 17 45" src="https://user-images.githubusercontent.com/32349530/57610268-6c661e80-75ab-11e9-9733-a9cdeb8c57d9.png">

確認をお願いします。